### PR TITLE
Fix bug where not providing solver causes omnisolver script to crash

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[report]
+omit = omnisolver/cmd.py

--- a/.github/workflows/quality_checks.yml
+++ b/.github/workflows/quality_checks.yml
@@ -45,5 +45,5 @@ jobs:
           use-black: true
           use-isort: true
           extra-flake8-options: --max-line-length=100
-          extra-mypy-options: --ignore-missing-imports --namespace-packages
+          extra-mypy-options: --explicit-package-bases --ignore-missing-imports --namespace-packages
           extra-isort-options: --check-only --profile black

--- a/omnisolver/cmd.py
+++ b/omnisolver/cmd.py
@@ -41,7 +41,7 @@ def main():
         "--vartype", help="Variable type", choices=["SPIN", "BINARY"], default="BINARY"
     )
 
-    solver_commands = root_parser.add_subparsers(title="Solvers", dest="solver")
+    solver_commands = root_parser.add_subparsers(title="Solvers", dest="solver", required=True)
 
     all_plugins = get_all_plugins(get_plugin_manager())
 


### PR DESCRIPTION
Currently, running `omnisolver` without any argument causes the script to crash. This is because subparser for solver selection is not marked as required. This PR fixes this.

How to test:
1. Install omnisolver from master branch. Run `omnisolver`, it should crash.
2. Install omnisolver from this branch. Run `omnisolver`, it should not crash, and instead print message that the solver argument is required.